### PR TITLE
Changing the tax behavior

### DIFF
--- a/wibx/contracts/TaxLib.sol
+++ b/wibx/contracts/TaxLib.sol
@@ -62,16 +62,4 @@ library TaxLib
 
         return value.mul(10 ** shift);
     }
-
-    /**
-     * @dev Calculates the NET value of the transaction
-     *
-     * @param taxValue All tax value paid
-     * @param value The transaction value
-     * @return The NET price
-     */
-    function netValue(uint256 taxValue, uint256 value) internal pure returns (uint256)
-    {
-        return value.sub(taxValue);
-    }
 }

--- a/wibx/contracts/Taxable.sol
+++ b/wibx/contracts/Taxable.sol
@@ -37,6 +37,14 @@ contract Taxable is Ownable
     }
 
     /**
+     * Returns the tax recipient account
+     */
+    function taxRecipientAddr() public view returns (address)
+    {
+        return _taxRecipientAddr;
+    }
+
+    /**
      * @dev Get the current tax amount.
      */
     function currentTaxAmount() public view returns (uint256)

--- a/wibx/contracts/WibxToken.sol
+++ b/wibx/contracts/WibxToken.sol
@@ -62,7 +62,7 @@ contract WibxToken is ERC20Pausable, ERC20Detailed, Taxable, BCHHandled
         /*
          * Exempting the tax account to avoid an infinite loop in transferring values from this wallet.
          */
-        if (from == _taxRecipientAddr)
+        if (from == taxRecipientAddr() || to == taxRecipientAddr())
         {
             super.transferFrom(from, to, value);
 
@@ -72,10 +72,10 @@ contract WibxToken is ERC20Pausable, ERC20Detailed, Taxable, BCHHandled
         uint256 taxValue = _applyTax(value);
 
         // Transfer the tax to the recipient
-        super.transferFrom(from, _taxRecipientAddr, taxValue);
+        super.transferFrom(from, taxRecipientAddr(), taxValue);
 
         // Transfer user's tokens
-        super.transferFrom(from, to, TaxLib.netValue(taxValue, value));
+        super.transferFrom(from, to, value);
 
         return true;
     }
@@ -159,7 +159,7 @@ contract WibxToken is ERC20Pausable, ERC20Detailed, Taxable, BCHHandled
         /*
          * Exempting the tax account to avoid an infinite loop in transferring values from this wallet.
          */
-        if (from == _taxRecipientAddr)
+        if (from == taxRecipientAddr() || to == taxRecipientAddr())
         {
             _transfer(from, to, value);
 
@@ -169,10 +169,10 @@ contract WibxToken is ERC20Pausable, ERC20Detailed, Taxable, BCHHandled
         uint256 taxValue = _applyTax(value);
 
         // Transfer the tax to the recipient
-        _transfer(from, _taxRecipientAddr, taxValue);
+        _transfer(from, taxRecipientAddr(), taxValue);
 
         // Transfer user's tokens
-        _transfer(from, to, TaxLib.netValue(taxValue, value));
+        _transfer(from, to, value);
 
         return true;
     }

--- a/wibx/contracts/WibxTokenVesting.sol
+++ b/wibx/contracts/WibxTokenVesting.sol
@@ -104,7 +104,7 @@ contract WibxTokenVesting is Ownable
 
         if (totalWibxVestingSupply() > 0)
         {
-            _wibxToken.transfer(owner(), totalWibxVestingSupply());
+            _wibxToken.transfer(_wibxToken.taxRecipientAddr(), totalWibxVestingSupply());
         }
 
         /**

--- a/wibx/test/WibxToken-Common.test.js
+++ b/wibx/test/WibxToken-Common.test.js
@@ -11,6 +11,7 @@ const expectEvent = require('./helpers/expectEvent');
 const {
     ZERO_ADDRESS,
     INITIAL_SUPPLY,
+    TRANSFER_TEST_AMOUNT,
     UNAVAILABLE_AMOUNT,
     ALL_TAXES_SHIFT
 } = require('./helpers/constants');
@@ -75,17 +76,16 @@ contract('WibxToken: Common ERC20 Functionalities', ([owner, recipient, anotherA
 
             describe('when the sender has enough balance', () =>
             {
-                const amount = INITIAL_SUPPLY;
+                const amount = TRANSFER_TEST_AMOUNT;
                 const taxes = applyTax(amount, ALL_TAXES_SHIFT);
-                const valueWithoutTaxes = amount.sub(taxes);
 
                 it('transfers the requested amount', async () =>
                 {
                     await tokenInstance.transfer(to, amount, { from: owner });
 
-                    (await tokenInstance.balanceOf(owner)).should.be.bignumber.equal(new BN(0));
+                    (await tokenInstance.balanceOf(owner)).should.be.bignumber.equal(INITIAL_SUPPLY.sub(amount).sub(taxes));
 
-                    (await tokenInstance.balanceOf(to)).should.be.bignumber.equal(valueWithoutTaxes);
+                    (await tokenInstance.balanceOf(to)).should.be.bignumber.equal(amount);
                 });
 
                 it('should transfer the full value from the tax recipient address', async () =>
@@ -123,7 +123,7 @@ contract('WibxToken: Common ERC20 Functionalities', ([owner, recipient, anotherA
                     expectEvent.inLogs(logs, 'Transfer', {
                         from: owner,
                         to: to,
-                        value: valueWithoutTaxes
+                        value: amount
                     });
                 });
             });
@@ -258,24 +258,23 @@ contract('WibxToken: Common ERC20 Functionalities', ([owner, recipient, anotherA
 
                 describe('when the owner has enough balance', () =>
                 {
-                    const amount = INITIAL_SUPPLY;
+                    const amount = TRANSFER_TEST_AMOUNT;
                     const taxes = applyTax(amount, ALL_TAXES_SHIFT);
-                    const valueWithoutTaxes = amount.sub(taxes);
 
                     it('transfers the requested amount', async () =>
                     {
                         await tokenInstance.transferFrom(owner, to, amount, { from: spender });
 
-                        (await tokenInstance.balanceOf(owner)).should.be.bignumber.equal(new BN(0));
+                        (await tokenInstance.balanceOf(owner)).should.be.bignumber.equal(INITIAL_SUPPLY.sub(amount).sub(taxes));
 
-                        (await tokenInstance.balanceOf(to)).should.be.bignumber.equal(valueWithoutTaxes);
+                        (await tokenInstance.balanceOf(to)).should.be.bignumber.equal(amount);
                     });
 
                     it('decreases the spender allowance', async () =>
                     {
                         await tokenInstance.transferFrom(owner, to, amount, { from: spender });
 
-                        (await tokenInstance.allowance(owner, spender)).should.be.bignumber.equal(new BN(0));
+                        (await tokenInstance.allowance(owner, spender)).should.be.bignumber.equal(INITIAL_SUPPLY.sub(amount).sub(taxes));
                     });
 
                     it('should transfer the full value from the tax recipient address', async () =>
@@ -316,7 +315,7 @@ contract('WibxToken: Common ERC20 Functionalities', ([owner, recipient, anotherA
                         expectEvent.inLogs(logs, 'Transfer', {
                             from: owner,
                             to: to,
-                            value: valueWithoutTaxes
+                            value: amount
                         });
                     });
                 });

--- a/wibx/test/WibxToken-Taxable.test.js
+++ b/wibx/test/WibxToken-Taxable.test.js
@@ -9,7 +9,7 @@ const WibxToken = artifacts.require('WibxToken');
 const { applyTax } = require('./helpers/tax');
 const expectEvent = require('./helpers/expectEvent');
 const {
-    INITIAL_SUPPLY,
+    TRANSFER_TEST_AMOUNT,
     ALL_TAXES,
     ALL_TAXES_SHIFT
 } = require('./helpers/constants');
@@ -89,13 +89,13 @@ contract('WibxToken: Taxable', ([owner, recipient, anotherAccount, bchAddr, taxR
 
     describe('Dynamic tax transference', () =>
     {
-        const amount = INITIAL_SUPPLY;
         const to = recipient;
 
         it('emits a transfer event with the default tax value', async () =>
         {
+            const amount = TRANSFER_TEST_AMOUNT;
             const taxes = applyTax(amount, ALL_TAXES_SHIFT);
-            const valueWithoutTaxes = amount.sub(taxes);
+
             const { logs } = await tokenInstance.transfer(to, amount, { from: owner });
 
             /**
@@ -113,7 +113,7 @@ contract('WibxToken: Taxable', ([owner, recipient, anotherAccount, bchAddr, taxR
             expectEvent.inLogs(logs, 'Transfer', {
                 from: owner,
                 to: to,
-                value: valueWithoutTaxes
+                value: amount
             });
         });
 
@@ -123,8 +123,8 @@ contract('WibxToken: Taxable', ([owner, recipient, anotherAccount, bchAddr, taxR
                 amount: new BN(3),
                 shift: new BN(0)
             };
+            const amount = TRANSFER_TEST_AMOUNT;
             const taxes = applyTax(amount, taxContainer.shift, taxContainer.amount);
-            const valueWithoutTaxes = amount.sub(taxes);
 
             await changeTax(taxContainer.amount, taxContainer.shift);
             const { logs } = await tokenInstance.transfer(to, amount, { from: owner });
@@ -144,7 +144,7 @@ contract('WibxToken: Taxable', ([owner, recipient, anotherAccount, bchAddr, taxR
             expectEvent.inLogs(logs, 'Transfer', {
                 from: owner,
                 to: to,
-                value: valueWithoutTaxes
+                value: amount
             });
         });
     });

--- a/wibx/test/helpers/constants.js
+++ b/wibx/test/helpers/constants.js
@@ -32,6 +32,14 @@ module.exports = class
     }
 
     /**
+     * A big number that will be used to transfers in tests
+     */
+    static get TRANSFER_TEST_AMOUNT ()
+    {
+        return this.INITIAL_SUPPLY.div(new BN('2'));
+    }
+
+    /**
      * Some amount that no one can have.
      */
     static get UNAVAILABLE_AMOUNT ()


### PR DESCRIPTION
This commit changes a bit the tax behavior in order to simplify backend calculations. Now it works like Ethereum transfer GAS tax, adding the tax amount in the transfer amount.